### PR TITLE
[Feat] Add periodic job to exclude abandoned carts

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -4,6 +4,10 @@ class Cart < ApplicationRecord
 
   validates_numericality_of :total_price, greater_than_or_equal_to: 0
 
+  scope :active,       -> { where(abandoned_at: nil) }
+  scope :abandoned,    -> { where.not(abandoned_at: nil) }
+  scope :inactive_for, ->(time_ago) { where("updated_at < ?", time_ago) }
+
   def add_product!(product, quantity)
     transaction do
       item = cart_items.find_or_initialize_by(product: product)

--- a/app/sidekiq/mark_cart_as_abandoned_job.rb
+++ b/app/sidekiq/mark_cart_as_abandoned_job.rb
@@ -1,7 +1,24 @@
 class MarkCartAsAbandonedJob
   include Sidekiq::Job
 
-  def perform(*args)
-    # TODO Impletemente um Job para gerenciar, marcar como abandonado. E remover carrinhos sem interação. 
+  def perform
+    mark_abandoned_carts
+    remove_old_abandoned_carts
+  end
+
+  private
+
+  def mark_abandoned_carts
+    Cart
+      .active
+      .inactive_for(3.hours.ago)
+      .update_all(abandoned_at: Time.current)
+  end
+
+  def remove_old_abandoned_carts
+    Cart
+      .abandoned
+      .where("abandoned_at < ?", 7.days.ago)
+      .destroy_all
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,3 +7,10 @@
   - mailers
   - active_storage_analysis
   - active_storage_purge
+
+scheduler:
+  enabled: true
+  schedule:
+    mark_cart_as_abandoned_job:
+      cron: "0 * * * *"  # run every hour at minute 0
+      class: "MarkCartAsAbandonedJob"

--- a/db/migrate/20250130014627_add_abandoned_at_to_carts.rb
+++ b/db/migrate/20250130014627_add_abandoned_at_to_carts.rb
@@ -1,0 +1,5 @@
+class AddAbandonedAtToCarts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :carts, :abandoned_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_29_210006) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_30_014627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_29_210006) do
     t.decimal "total_price", precision: 17, scale: 2
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "abandoned_at"
   end
 
   create_table "products", force: :cascade do |t|

--- a/spec/sidekiq/mark_cart_as_abandoned_job_spec.rb
+++ b/spec/sidekiq/mark_cart_as_abandoned_job_spec.rb
@@ -1,3 +1,42 @@
 require 'rails_helper'
+
 RSpec.describe MarkCartAsAbandonedJob, type: :job do
+  let(:three_hours_ago) { 3.hours.ago }
+  let(:four_hours_ago)  { 4.hours.ago }
+  let(:eight_days_ago)  { 8.days.ago }
+  let(:six_days_ago)    { 6.days.ago }
+
+  let!(:active_old_cart) do
+    create(:cart, abandoned_at: nil, updated_at: four_hours_ago)
+  end
+
+  let!(:active_recent_cart) do
+    create(:cart, abandoned_at: nil, updated_at: 1.hour.ago)
+  end
+
+  let!(:abandoned_old_cart) do
+    create(:cart, abandoned_at: eight_days_ago, updated_at: eight_days_ago)
+  end
+
+  let!(:abandoned_recent_cart) do
+    create(:cart, abandoned_at: six_days_ago, updated_at: six_days_ago)
+  end
+
+  describe "#perform" do
+    it "marks old active carts as abandoned and removes old abandoned carts" do
+      expect(active_old_cart.abandoned_at).to be_nil
+      expect(active_recent_cart.abandoned_at).to be_nil
+      expect(Cart.exists?(abandoned_old_cart.id)).to be true
+      expect(Cart.exists?(abandoned_recent_cart.id)).to be true
+
+      expect {
+        MarkCartAsAbandonedJob.new.perform
+      }.to change { Cart.count }.by(-1)
+
+      expect(active_old_cart.reload.abandoned_at).not_to be_nil
+      expect(active_recent_cart.reload.abandoned_at).to be_nil
+      expect(Cart.exists?(abandoned_old_cart.id)).to be false
+      expect(Cart.exists?(abandoned_recent_cart.id)).to be true
+    end
+  end
 end


### PR DESCRIPTION
# Problem

:ticket: [RDSTA-7](https://sites.plane.so/issues/4b56811a0473405f883b3eb2eed3ba8b/?board=kanban&peekId=165534fe-a805-4b06-bccb-7558443befd5)

Um carrinho é considerado abandonado quando estiver sem interação (adição ou remoção de produtos) há mais de 3 horas.

- Quando este cenário ocorrer, o carrinho deve ser marcado como abandonado.
- Se o carrinho estiver abandonado há mais de 7 dias, remover o carrinho.
- Utilize um Job para gerenciar (marcar como abandonado e remover) carrinhos sem interação.
- Configure a aplicação para executar este Job nos períodos especificados acima.